### PR TITLE
Update to latest API and add advanced propertfies.

### DIFF
--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAbstractProducer.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAbstractProducer.java
@@ -99,7 +99,7 @@ public abstract class SolaceJcsmpAbstractProducer extends ProduceOnlyProducerImp
       translatedMessage.setCorrelationKey(msg.getUniqueId());
 
       jcsmpMessageProducer.send(translatedMessage, dest);
-      getAsynEventHandler().addUnAckedMessage(translatedMessage.getMessageId(), msg);
+      getAsynEventHandler().addUnAckedMessage(msg);
       // Standard workflow will attempt to execute this after the produce,
       // let's remove them so it's handled by our async event handler.
       msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK);

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAdvancedConnectionProperties.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAdvancedConnectionProperties.java
@@ -1,0 +1,490 @@
+package com.adaptris.core.jcsmp.solace;
+
+import static com.solacesystems.jcsmp.JCSMPProperties.ACK_EVENT_MODE;
+import static com.solacesystems.jcsmp.JCSMPProperties.APPLICATION_DESCRIPTION;
+import static com.solacesystems.jcsmp.JCSMPProperties.CALCULATE_MESSAGE_EXPIRATION;
+import static com.solacesystems.jcsmp.JCSMPProperties.CLIENT_CHANNEL_PROPERTIES;
+import static com.solacesystems.jcsmp.JCSMPProperties.CLIENT_NAME;
+import static com.solacesystems.jcsmp.JCSMPProperties.GD_RECONNECT_FAIL_ACTION;
+import static com.solacesystems.jcsmp.JCSMPProperties.GD_RECONNECT_FAIL_ACTION_AUTO_RETRY;
+import static com.solacesystems.jcsmp.JCSMPProperties.GD_RECONNECT_FAIL_ACTION_DISCONNECT;
+import static com.solacesystems.jcsmp.JCSMPProperties.GENERATE_RCV_TIMESTAMPS;
+import static com.solacesystems.jcsmp.JCSMPProperties.GENERATE_SENDER_ID;
+import static com.solacesystems.jcsmp.JCSMPProperties.GENERATE_SEND_TIMESTAMPS;
+import static com.solacesystems.jcsmp.JCSMPProperties.GENERATE_SEQUENCE_NUMBERS;
+import static com.solacesystems.jcsmp.JCSMPProperties.IGNORE_DUPLICATE_SUBSCRIPTION_ERROR;
+import static com.solacesystems.jcsmp.JCSMPProperties.IGNORE_SUBSCRIPTION_NOT_FOUND_ERROR;
+import static com.solacesystems.jcsmp.JCSMPProperties.KRB_SERVICE_NAME;
+import static com.solacesystems.jcsmp.JCSMPProperties.MESSAGE_ACK_MODE;
+import static com.solacesystems.jcsmp.JCSMPProperties.MESSAGE_CALLBACK_ON_REACTOR;
+import static com.solacesystems.jcsmp.JCSMPProperties.NO_LOCAL;
+import static com.solacesystems.jcsmp.JCSMPProperties.PUB_ACK_TIME;
+import static com.solacesystems.jcsmp.JCSMPProperties.PUB_ACK_WINDOW_SIZE;
+import static com.solacesystems.jcsmp.JCSMPProperties.PUB_USE_INTERMEDIATE_DIRECT_BUF;
+import static com.solacesystems.jcsmp.JCSMPProperties.REAPPLY_SUBSCRIPTIONS;
+import static com.solacesystems.jcsmp.JCSMPProperties.SUB_ACK_TIME;
+import static com.solacesystems.jcsmp.JCSMPProperties.SUB_ACK_WINDOW_SIZE;
+import static com.solacesystems.jcsmp.JCSMPProperties.SUB_ACK_WINDOW_THRESHOLD;
+import static com.solacesystems.jcsmp.JCSMPProperties.SUPPORTED_ACK_EVENT_MODE_PER_MSG;
+import static com.solacesystems.jcsmp.JCSMPProperties.SUPPORTED_ACK_EVENT_MODE_WINDOWED;
+import static com.solacesystems.jcsmp.JCSMPProperties.SUPPORTED_MESSAGE_ACK_AUTO;
+import static com.solacesystems.jcsmp.JCSMPProperties.SUPPORTED_MESSAGE_ACK_CLIENT;
+
+import javax.validation.constraints.Pattern;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
+import com.solacesystems.jcsmp.JCSMPChannelProperties;
+import com.solacesystems.jcsmp.JCSMPProperties;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * <p>
+ * Advanced properties specifically for {@Link SolaceJcsmpConnection}
+ * </p>
+ * @author Aaron
+ * @config solace-jcsmp-connection-properties
+ */
+@AdapterComponent
+@ComponentProfile(summary="Advanced connection properties for the JCSMP connection.", tag="connection,solace,jcsmp", since="4.3")
+@XStreamAlias("solace-jcsmp-connection-properties")
+public class SolaceJcsmpAdvancedConnectionProperties {
+  
+  /**
+   * (Optional) Indicates whether the acknowledgement of receiving a message is done by JCSMP automatically 
+   * or by the application explicitly calling XMLMessage.ackMessage(). If message acknowledgement mode should be handled automatically, 
+   * then set to "false".  If however you wish for the more explicit client mode, set to "true".
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value = "false")
+  private boolean clientAckMode;
+  
+  /**
+   * (Optional) The client description to report to an appliance. The maximum length is 254 ASCII characters. Setting this property is optional.
+   */
+  @Setter
+  @Getter
+  private String applicationDescription;
+  
+  /**
+   * (Optional) A unique client name to use to register to the appliance. If specified, it must be a valid Topic name, and a maximum of 
+   * 160 bytes in length when encoded as UTF-8.  
+   * If a value of "" is specified, the default (auto-generated) client name is applied.
+   */
+  @Getter
+  @Setter
+  private String clientName;
+  
+  /**
+   * (Optional) Indicates whether the client name should be included in the SenderID message header parameter.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value = "false")
+  private boolean generateSenderId;
+  
+  /**
+   * The size of the sliding subscriber ACK window. The valid range is 1-255.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value = "255")
+  private int subAckWindowSize;
+  
+  /**
+   * The size of the sliding publisher window for Guaranteed messages. The Guaranteed Message Publish Window Size 
+   * property limits the maximum number of messages that can be published before the API must receive an 
+   * acknowledgement from the appliance. The valid range is 1-255.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value = "1")
+  private int pubAckWindowSize;
+  
+  /**
+   * The duration of the subscriber ACK timer (in milliseconds). The valid range is 20-1500.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value = "1000")
+  private int subAckTime;
+  
+  /**
+   * The duration of the publisher acknowledgement timer (in milliseconds). When a published 
+   * message is not acknowledged within the time specified for this timer, the API automatically 
+   * retransmits the message. The valid range is 20-60000.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="2000")
+  private int pubAckTime;
+  
+  /**
+   * The threshold for sending an acknowledgement, configured as a percentage. 
+   * The API sends a transport acknowledgment every N messages where N is calculated as this 
+   * percentage of the flow window size if the endpoint's max-delivered-unacked-msgs-per-flow 
+   * setting at bind time is greater than or equal to the transport window size. Otherwise, N is 
+   * calculated as this percentage of the endpoint's max-delivered-unacked-msgs-per-flow 
+   * setting at bind time. The valid range is 1-75.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="60")
+  private int subAckWindowThreshold;
+  
+  /**
+   * (Optional) Indicates whether to generate a receive timestamp on incoming messages.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="false")
+  private boolean generateRcvTimestamps;
+  
+  /**
+   * (Optional) Indicates whether to generate a send timestamp in outgoing messages.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="false")
+  private boolean generateSendTimestamps;
+  
+  /**
+   * (Optional) Indicates whether to generate a sequence number in outgoing messages.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="false")
+  private boolean generateSequenceNumbers;
+  
+  /**
+   * (Optional) Indicates whether to calculate message expiration time in 
+   * outgoing messages and incoming messages.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="false")
+  private boolean calculateMessageExpiration;
+  
+  /**
+   * If enabled, the API maintains a local cache of subscriptions and reapplies them when 
+   * the subscriber connection is reestablished. Reapply subscriptions will only apply 
+   * direct topic subscriptions unpon a Session reconnect. It will not reapply topic 
+   * subscriptions on durable and non-durable endpoints.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="false")
+  private boolean reapplySubscriptions;
+  
+  /**
+   * Defaults to true. If enabled, during send operations, the XMLMessageProducer concatenates 
+   * all published data to an intermediate direct ByteBuffer in the API, and writes only 
+   * that buffer to the socket instead of performing a vectored write(ByteBuffer[]) operation.
+   * This can result in higher throughput for certain send operations. It can, however, lead to 
+   * performance degradation for some scenarios with large messages or sendMultiple(...) 
+   * operations, especially if messages are already using direct ByteBuffers for data storage. 
+   * This property should be set to false in those conditions.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="true")
+  private boolean pubUseIntermediateDirectBuf = true;
+  
+  /**
+   * If enabled, messages delivered asynchronously to an XMLMessageListener are delivered directly from the I/O 
+   * thread instead of a consumer notification thread. An application making use of this setting MUST 
+   * return quickly from the onReceive() callback, and MUST NOT call ANY session methods from the I/O thread.
+   * The above means that calling any blocking methods from an XMLMessageListener callback is not 
+   * supported and may cause an application to deadlock.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="false")
+  private boolean messageCallbackOnReactor;
+  
+  /**
+   * On addSubscription(Subscription), addSubscription(Endpoint, Subscription, int), or addSubscriptions(XpeList), ignore errors caused by subscriptions being already present.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="false")
+  private boolean ignoreDuplicateSubscriptionError;
+  
+  /**
+   * On removeSubscription(Subscription), removeSubscription(Endpoint, Subscription, int), or removeSubscriptions(XpeList), ignore errors caused by subscriptions not being found.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="false")
+  private boolean ignoreSubscriptionNotFoundError;
+  
+  /**
+   * If this property is true, messages published on the session will not be received on 
+   * the same session even if the client has a subscription that matches the published topic. 
+   * If this restriction is requested and the appliance does not have No Local support, 
+   * the session connect will fail.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="false")
+  private boolean noLocal;
+  
+  /**
+   * SUPPORTED_ACK_EVENT_MODE_PER_MSG  or  SUPPORTED_ACK_EVENT_MODE_WINDOWED
+   * If this property is set to SUPPORTED_ACK_EVENT_MODE_PER_MSG, the message acknowledgement 
+   * event acknowledges a single published Guaranteed message; if this property is set to 
+   * SUPPORTED_ACK_EVENT_MODE_WINDOWED, the message acknowledgement event acknowledges a 
+   * range of published Guaranteed messages.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="SUPPORTED_ACK_EVENT_MODE_PER_MSG")
+  @Pattern(regexp="SUPPORTED_ACK_EVENT_MODE_PER_MSG|SUPPORTED_ACK_EVENT_MODE_WINDOWED")
+  private String ackEventMode;
+  
+  /**
+   * This property is used to specify the ServiceName portion of the Service Principal Name (SPN) that has a format of ServiceName/ApplianceName@REALM.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="solace")
+  private String krbServiceName;
+  
+  /**
+   * GD_RECONNECT_FAIL_ACTION_AUTO_RETRY  or  GD_RECONNECT_FAIL_ACTION_DISCONNECT
+   * Defines the behavior when the API is unable to reconnect guaranteed delivery after reconnecting the session. 
+   * This may occur if the session is configured with a host list where each Solace router in the host list is unaware 
+   * of state on the previous router. It can also occur if the time to reconnect to the same router exceeds the publisher flow timeout on the router.
+   */
+  @Setter
+  @Getter
+  @Pattern(regexp = "GD_RECONNECT_FAIL_ACTION_AUTO_RETRY|GD_RECONNECT_FAIL_ACTION_DISCONNECT")
+  @InputFieldDefault(value="GD_RECONNECT_FAIL_ACTION_AUTO_RETRY")
+  private String gdReconnectFailAction;
+  
+  /**
+   * Timeout value (in ms) for creating an initial connection to the appliance. Valid values are >= 0. 0 means an infinite timeout.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="30000")
+  private int channelConnectTimeoutInMillis;
+  
+  /**
+   * Timeout value (in ms) for reading a reply from the appliance. Valid values are > 0.
+   * Note: For subscriber control channels, the default is 120000 ms.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="10000")
+  private int channelReadTimeoutInMillis;
+  
+  /**
+   * The number of times to attempt and retry a connection to the host appliance (or list of appliances) during initial connection setup. 
+   * Valid values are >= -1. Zero means no automatic connection retries (that is, try once and give up). -1 means "retry forever".
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="0")
+  private int channelConnectRetries;
+  
+  /**
+   * The number of times to attempt to reconnect to the appliance (or list of appliances) after an initial connected session goes down. 
+   * Valid values are >= -1. -1 means "retry forever". 0 means no automatic reconnection retries (that is, try once and give up).
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="3")
+  private int channelReconnectRetries;
+  
+  /**
+   * When using a host list for the HOST property, this property defines how many
+   * times to try to connect or reconnect to a single host before moving to the
+   * next host in the list. NOTE: This property works in conjunction with the
+   * connect and reconnect retries settings; it does not replace them. Valid
+   * values are >= -1. 0 means make a single connection attempt (that is, 0
+   * retries). -1 means attempt an infinite number of reconnect retries (that is,
+   * the API only tries to connect or reconnect to first host listed.)
+   */
+  
+  @Setter
+  @Getter
+  @InputFieldDefault(value="0")
+  private int channelConnectRetriesPerHost;
+  
+  /**
+   * How much time in (MS) to wait between each attempt to connect or reconnect to
+   * a host. If a connect or reconnect attempt to host is not successful, the API
+   * waits for the amount of time set for reconnectRetryWaitInMillis, and then
+   * makes another connect or reconnect attempt. Note: connectRetriesPerHost sets
+   * how many connection or reconnection attempts can be made before moving on to
+   * the next host in the list. See the HOST for more details on the reconnect
+   * logic.
+   * 
+   * Valid values are 0 - 60000, inclusively.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="3000")
+  private int channelReconnectRetryWaitInMillis;
+  
+  /**
+   * The amount of time (in ms) to wait between sending out keep-alive messages.
+   * Typically, this feature should be enabled for message receivers. Valid values
+   * are >= 50. 0 disables the keepalive function. Note: If using compression on a
+   * session, the configured KeepAlive interval should be longer than the maximum
+   * time required to compress the largest message likely to be published.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="3000")
+  private int channelKeepAliveIntervalInMillis;
+  
+  /**
+   * The maximum number of consecutive keep-alive messages that can be sent without receiving a response before the connection is closed by the API.
+   * Valid values are >= 3.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="10")
+  private int channelKeepAliveLimit;
+  
+  /**
+   * The size (in bytes) of the send socket buffer.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="65536")
+  private int channelSendBuffer;
+  
+  /**
+   * The size (in bytes) of the receive socket buffer.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="65536")
+  private int channelReceiveBuffer;
+  
+  /**
+   * Whether to set the TCP_NODELAY option. When enabled, this option disables the Nagle's algorithm.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="true")
+  private boolean channelTcpNoDelay;
+  
+  /**
+   * A compressionLevel setting of 1-9 sets the ZLIB compression level to use; a
+   * setting of 0 disables compression entirely. From the ZLIB manual: [...] 1
+   * gives best speed, 9 gives best compression, 0 gives no compression at all
+   * (the input data is simply copied a block at a time).
+   * 
+   * Note: If using compression on a session, the configured KeepAlive interval
+   * should be longer than the maximum time required to compress the largest
+   * message likely to be published.
+   */
+  @Setter
+  @Getter
+  @InputFieldDefault(value="0")
+  private int channelCompressionLevel;
+  
+  public SolaceJcsmpAdvancedConnectionProperties() {
+    setSubAckWindowSize(255);
+    setPubAckWindowSize(1);
+    setSubAckTime(1000);
+    setPubAckTime(2000);
+    setSubAckWindowThreshold(60);
+    setPubUseIntermediateDirectBuf(true);
+    setAckEventMode("SUPPORTED_ACK_EVENT_MODE_PER_MSG");
+    setGdReconnectFailAction("GD_RECONNECT_FAIL_ACTION_AUTO_RETRY");
+    setChannelConnectTimeoutInMillis(30000);
+    setChannelReadTimeoutInMillis(10000);
+    setChannelConnectRetries(0);
+    setChannelReconnectRetries(3);
+    setChannelConnectRetriesPerHost(0);
+    setChannelReconnectRetryWaitInMillis(3000);
+    setChannelKeepAliveIntervalInMillis(3000);
+    setChannelKeepAliveLimit(10);
+    setChannelSendBuffer(65536);
+    setChannelReceiveBuffer(65536);
+    setChannelTcpNoDelay(true);
+    setChannelCompressionLevel(0);
+  }
+  
+  public void applyAdvancedProperties(JCSMPProperties properties) {
+    JCSMPChannelProperties channelProps = new JCSMPChannelProperties();
+    channelProps.setConnectTimeoutInMillis(getChannelConnectTimeoutInMillis());
+    channelProps.setReadTimeoutInMillis(getChannelReadTimeoutInMillis());
+    channelProps.setConnectRetries(getChannelConnectRetries());
+    channelProps.setReconnectRetries(getChannelReconnectRetries());
+    channelProps.setConnectRetriesPerHost(getChannelConnectRetriesPerHost());
+    channelProps.setReconnectRetryWaitInMillis(getChannelReconnectRetryWaitInMillis());
+    channelProps.setKeepAliveIntervalInMillis(getChannelKeepAliveIntervalInMillis());
+    channelProps.setKeepAliveLimit(getChannelKeepAliveLimit());
+    channelProps.setSendBuffer(getChannelSendBuffer());
+    channelProps.setReceiveBuffer(getChannelReceiveBuffer());
+    channelProps.setTcpNoDelay(getChannelTcpNoDelay());
+    channelProps.setCompressionLevel(getChannelCompressionLevel());
+    
+    properties.setProperty(CLIENT_CHANNEL_PROPERTIES, channelProps);
+    
+    properties.setProperty(MESSAGE_ACK_MODE, getClientAckMode() ? SUPPORTED_MESSAGE_ACK_CLIENT : SUPPORTED_MESSAGE_ACK_AUTO);
+    
+    if(getApplicationDescription() != null)
+      properties.setProperty(APPLICATION_DESCRIPTION, getApplicationDescription());
+    
+    if(getClientName() != null)
+      properties.setProperty(CLIENT_NAME, getClientName());
+    
+    properties.setBooleanProperty(GENERATE_SENDER_ID, getGenerateSenderId());
+    
+    if(getSubAckWindowSize() > 0)
+      properties.setIntegerProperty(SUB_ACK_WINDOW_SIZE, getSubAckWindowSize());
+    
+    if(getPubAckWindowSize() > 0)
+      properties.setIntegerProperty(PUB_ACK_WINDOW_SIZE, getPubAckWindowSize());
+    
+    if(getSubAckTime() > 0)
+      properties.setIntegerProperty(SUB_ACK_TIME, getSubAckTime());
+    
+    if(getPubAckTime() > 0)
+      properties.setIntegerProperty(PUB_ACK_TIME, getPubAckTime());
+    
+    if(getSubAckWindowThreshold() > 0)
+      properties.setIntegerProperty(SUB_ACK_WINDOW_THRESHOLD, getSubAckWindowThreshold());
+    
+    properties.setBooleanProperty(GENERATE_RCV_TIMESTAMPS, getGenerateRcvTimestamps());
+    
+    properties.setBooleanProperty(GENERATE_SEND_TIMESTAMPS, getGenerateSendTimestamps());
+    
+    properties.setBooleanProperty(GENERATE_SEQUENCE_NUMBERS, getGenerateSequenceNumbers());
+    
+    properties.setBooleanProperty(CALCULATE_MESSAGE_EXPIRATION, getCalculateMessageExpiration());
+    
+    properties.setBooleanProperty(REAPPLY_SUBSCRIPTIONS, getReapplySubscriptions());
+    
+    properties.setBooleanProperty(PUB_USE_INTERMEDIATE_DIRECT_BUF, getPubUseIntermediateDirectBuf());
+    
+    properties.setBooleanProperty(MESSAGE_CALLBACK_ON_REACTOR, getMessageCallbackOnReactor());
+    
+    properties.setBooleanProperty(IGNORE_DUPLICATE_SUBSCRIPTION_ERROR, getIgnoreDuplicateSubscriptionError());
+    
+    properties.setBooleanProperty(IGNORE_SUBSCRIPTION_NOT_FOUND_ERROR, getIgnoreSubscriptionNotFoundError());
+    
+    properties.setBooleanProperty(NO_LOCAL, getNoLocal());
+    
+    if(getAckEventMode() != null)
+      properties.setProperty(ACK_EVENT_MODE, getAckEventMode().equals("SUPPORTED_ACK_EVENT_MODE_PER_MSG") ? SUPPORTED_ACK_EVENT_MODE_PER_MSG : SUPPORTED_ACK_EVENT_MODE_WINDOWED);
+    
+    if(getKrbServiceName() != null)
+      properties.setProperty(KRB_SERVICE_NAME, getKrbServiceName());
+    
+    if(getGdReconnectFailAction() != null)   
+      properties.setProperty(GD_RECONNECT_FAIL_ACTION, getGdReconnectFailAction().equals("GD_RECONNECT_FAIL_ACTION_AUTO_RETRY") ? GD_RECONNECT_FAIL_ACTION_AUTO_RETRY : GD_RECONNECT_FAIL_ACTION_DISCONNECT);
+  }
+}

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpConnection.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpConnection.java
@@ -75,9 +75,15 @@ public class SolaceJcsmpConnection extends AllowsRetriesConnection implements So
   @Getter
   @Setter
   private Boolean additionalDebug;
+  
+  @AdvancedConfig
+  @Getter
+  @Setter
+  private SolaceJcsmpAdvancedConnectionProperties advancedProperties;
 
   public SolaceJcsmpConnection() {
     super();
+    setAdvancedProperties(new SolaceJcsmpAdvancedConnectionProperties());
   }
 
   @Override
@@ -155,6 +161,8 @@ public class SolaceJcsmpConnection extends AllowsRetriesConnection implements So
     }
     properties.setProperty(JCSMPProperties.HOST, getHost());
     properties.setProperty(JCSMPProperties.VPN_NAME, getVpn());
+    
+    getAdvancedProperties().applyAdvancedProperties(properties);
 
     return properties;
   }

--- a/src/main/java/com/adaptris/core/jcsmp/solace/auth/CertificateAuthenticationProvider.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/auth/CertificateAuthenticationProvider.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.annotation.InputFieldDefault;
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.CoreException;
 import com.adaptris.interlok.resolver.ExternalResolver;
@@ -63,6 +64,26 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
   private String sslTrustStorePassword;
   
   /**
+   * (Optional) This property is used to specify the format of the truststore given in SSL_TRUST_STORE.
+   */
+  @Getter
+  @Setter
+  private String sslTrustStoreFormat;
+  
+  /**
+   * This property is used to specify a comma separated list of acceptable common 
+   * names for matching with server certificates. The API performs a case insensitive 
+   * comparison of the common names provided in this property with the common name in the 
+   * server certificate. Note that leading and trailing whitespaces are considered to be 
+   * part of the common names and are not ignored. An empty string means accept all common 
+   * names. No common name validation will be performed (overriding this property) 
+   * if SSL_VALIDATE_CERTIFICATE is set to false.
+   */
+  @Getter
+  @Setter
+  private String sslTrustedCommonNameList;
+  
+  /**
    * The Solace client property to specify the location of your key store.
    * @param validateCertificate
    */
@@ -79,6 +100,22 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
   @Getter
   @Setter
   private String sslKeyStorePassword;
+  
+  /**
+   * (Optional) This property is used to specify the format of the keystore given in SSL_KEY_STORE.
+   */
+  @Getter
+  @Setter
+  private String sslKeyStoreFormat;
+  
+  /**
+   * This property is used to specify the alias of the private key to use for client certificate authentication. 
+   * If there is only one private key entry in the keystore specified by SSL_KEY_STORE, then this property doesn't have to be set.
+   */
+  @Getter
+  @Setter
+  @InputFieldDefault(value="")
+  private String sslPrivateKeyAlias;
   
   @Override
   public JCSMPProperties initConnectionProperties() throws CoreException {
@@ -98,12 +135,24 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
       setProperty(properties, JCSMPProperties.SSL_TRUST_STORE_PASSWORD, 
           decodeFunction(), 
           Optional.ofNullable(getSslTrustStorePassword()));
+      setProperty(properties, JCSMPProperties.SSL_TRUST_STORE_FORMAT, 
+          noOpFunction(), 
+          Optional.ofNullable(getSslTrustStoreFormat()));
+      setProperty(properties, JCSMPProperties.SSL_TRUSTED_COMMON_NAME_LIST, 
+          noOpFunction(), 
+          Optional.ofNullable(getSslTrustedCommonNameList()));
       setProperty(properties, JCSMPProperties.SSL_KEY_STORE, 
           noOpFunction(), 
           Optional.ofNullable(getSslKeyStoreLocation()));
+      setProperty(properties, JCSMPProperties.SSL_PRIVATE_KEY_ALIAS, 
+          noOpFunction(), 
+          Optional.ofNullable(getSslPrivateKeyAlias()));
       setProperty(properties, JCSMPProperties.SSL_KEY_STORE_PASSWORD, 
           decodeFunction(), 
           Optional.ofNullable(getSslKeyStorePassword()));
+      setProperty(properties, JCSMPProperties.SSL_KEY_STORE_FORMAT, 
+          decodeFunction(), 
+          Optional.ofNullable(getSslKeyStoreFormat()));
 
     } catch (Exception pe) {
       throw new CoreException(pe);

--- a/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpPerMessageProperties.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpPerMessageProperties.java
@@ -1,0 +1,357 @@
+package com.adaptris.core.jcsmp.solace.translator;
+
+import com.adaptris.annotation.InputFieldHint;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.util.KeyValuePair;
+import com.adaptris.util.KeyValuePairList;
+import com.solacesystems.jcsmp.DeliveryMode;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.SDTException;
+import com.solacesystems.jcsmp.SDTMap;
+import com.solacesystems.jcsmp.User_Cos;
+import com.solacesystems.jcsmp.XMLMessage;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class SolaceJcsmpPerMessageProperties {
+
+  /**
+   * Set the user data through name/values pairs
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private KeyValuePairList userProperties;
+  
+  /**
+   * Set the ACK Immediately message property.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String ackImmediately;
+  
+  /**
+   * Sets the message ID (a string for an application-specific message identifier).
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String applicationMessageId;
+  
+  /**
+   * Sets the reply field of the message.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String asReplyMessage;
+  
+  /**
+   * Sets the correlation ID.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String correlationId;
+  
+  /**
+   * Sets the correlation key.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String correlationKey;
+  
+  /**
+   * Sets the Class of Service (CoS) value for this message. 1 being the lowest class of service and 3 being the highest.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String classOfService;
+  
+  /**
+   * Sets the delivery mode of the message.  Should be one of the following; DIRECT|NON_PERSISTENT|PERSISTENT
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String deliveryMode;
+  
+  /**
+   * Set the message to be eligible to be moved to a Dead Message Queue.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String dmqEligible;
+  
+  /**
+   * Sets whether the message is eligible for eliding.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String elidingEligible;
+  
+  /**
+   * The UTC time (in milliseconds, from midnight, January 1, 1970 UTC) when the message is supposed to expire.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String expiration;
+  
+  /**
+   * Sets the HTTP content type encoding value for interaction with an HTTP client.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String httpContentEncoding;
+  
+  /**
+   * Sets the HTTP content type value for interaction with an HTTP client.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String httpContentType;
+  
+  /**
+   * A message can optionally have priority set.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String priority;
+  
+  /**
+   * Sets the replyTo destination (queue) for the message.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String replyToQueue;
+  
+  /**
+   * Sets the replyTo destination (topic) for the message.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String replyToTopic;
+  
+  /**
+   * Appends a String to the session's default ReplyTo base topic and creates a ReplyTo Topic Destination.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String replyToSuffix;
+  
+  /**
+   * Sets the Sender ID for the message.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String senderId;
+  
+  /**
+   * Allows the application to set the send timestamp, if so the API will not generate a value.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String senderTimestamp;
+  
+  /**
+   * Sets the sequence number.
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String sequenceNumber;
+  
+  /**
+   * The number of milliseconds before the message is discarded or moved to a Dead Message Queue.
+   * 
+   */
+  @Getter
+  @Setter
+  @InputFieldHint(expression=true)
+  private String timeToLive;
+  
+  public void applyPerMessageProperties(AdaptrisMessage destMessage, XMLMessage sourceMessage) throws SDTException {
+    if((sourceMessage.getApplicationMessageId() != null) && (getApplicationMessageId() != null))
+      destMessage.addMetadata(getApplicationMessageId(), sourceMessage.getApplicationMessageId());
+    
+    destMessage.addMetadata("discardIndication", Boolean.toString(sourceMessage.getDiscardIndication()));
+    destMessage.addMetadata("ackMessageId", Long.toString(sourceMessage.getAckMessageId()));
+    
+    if(sourceMessage.getApplicationMessageType() != null)
+      destMessage.addMetadata("applicationMessageType", sourceMessage.getApplicationMessageType());
+    
+    if(sourceMessage.getCacheRequestId() != null)
+      destMessage.addMetadata("cacheRequestId", Long.toString(sourceMessage.getCacheRequestId()));
+    destMessage.addMetadata("contentLength", Long.toString(sourceMessage.getContentLength()));
+    
+    if((sourceMessage.getCorrelationId() != null) && (getCorrelationId() != null))
+      destMessage.addMetadata(getCorrelationId(), sourceMessage.getCorrelationId());
+    
+    if((sourceMessage.getCorrelationKey() != null) && (getCorrelationKey() != null))
+      destMessage.addMetadata(getCorrelationKey(), sourceMessage.getCorrelationKey().toString());
+    
+    if((sourceMessage.getCos() != null) && (getClassOfService() != null))
+      destMessage.addMetadata(getClassOfService(), sourceMessage.getCos().equals(User_Cos.USER_COS_1) ? "1" : sourceMessage.getCos().equals(User_Cos.USER_COS_2) ? "2" : "3");
+    
+    if((sourceMessage.getDeliveryMode() != null) && (getDeliveryMode() != null))
+      destMessage.addMetadata(getDeliveryMode(), sourceMessage.getDeliveryMode().name());
+    
+    if(getAckImmediately() != null)
+      destMessage.addMetadata(getAckImmediately(), Boolean.toString(sourceMessage.isAckImmediately()));
+    destMessage.addMetadata("cacheMessage", Boolean.toString(sourceMessage.isCacheMessage()));
+    if(getElidingEligible() != null)
+      destMessage.addMetadata(getElidingEligible(), Boolean.toString(sourceMessage.isElidingEligible()));
+    if(getDmqEligible() != null)
+      destMessage.addMetadata(getDmqEligible(), Boolean.toString(sourceMessage.isDMQEligible()));
+    if(getAsReplyMessage() != null)
+      destMessage.addMetadata(getAsReplyMessage(), Boolean.toString(sourceMessage.isReplyMessage()));
+    
+    destMessage.addMetadata("structuredMessage", Boolean.toString(sourceMessage.isStructuredMsg()));
+    destMessage.addMetadata("suspect", Boolean.toString(sourceMessage.isSuspect()));
+    
+    if(getExpiration() != null)
+      destMessage.addMetadata(getExpiration(), Long.toString(sourceMessage.getExpiration()));
+    
+    if((sourceMessage.getHTTPContentEncoding() != null) && (getHttpContentEncoding() != null))
+      destMessage.addMetadata(getHttpContentEncoding(), sourceMessage.getHTTPContentEncoding());
+    
+    if((sourceMessage.getHTTPContentType() != null) && (getHttpContentType() != null))
+      destMessage.addMetadata(getHttpContentType(), sourceMessage.getHTTPContentType());
+    
+    if(getPriority() != null)
+      destMessage.addMetadata(getPriority(), Integer.toString(sourceMessage.getPriority()));
+    
+    destMessage.addMetadata("receiveTimestamp", Long.toString(sourceMessage.getReceiveTimestamp()));
+    destMessage.addMetadata("redelivered", Boolean.toString(sourceMessage.getRedelivered()));
+    
+    if(sourceMessage.getReplyTo() != null)
+      destMessage.addMetadata("replyTo", sourceMessage.getReplyTo().getName());
+    
+    if((sourceMessage.getReplyToSuffix() != null) && (getReplyToSuffix() != null))
+      destMessage.addMetadata(getReplyToSuffix(), sourceMessage.getReplyToSuffix());
+    
+    if((sourceMessage.getSenderId() != null) && (getSenderId() != null))
+      destMessage.addMetadata(getSenderId(), sourceMessage.getSenderId());
+    
+    if((sourceMessage.getSenderTimestamp() != null) && (getSenderTimestamp() != null))
+      destMessage.addMetadata(getSenderTimestamp(), Long.toString(sourceMessage.getSenderTimestamp()));
+    
+    if((sourceMessage.getSequenceNumber() != null) && (getSequenceNumber() != null))
+      destMessage.addMetadata(getSequenceNumber(), Long.toString(sourceMessage.getSequenceNumber()));
+    
+    if(getTimeToLive() != null)
+      destMessage.addMetadata(getTimeToLive(), Long.toString(sourceMessage.getTimeToLive()));
+    
+    if(sourceMessage.getProperties() != null) {
+      for(String key : sourceMessage.getProperties().keySet()) {
+        Object object = sourceMessage.getProperties().get(key);
+        
+        if(object instanceof String)
+          destMessage.addMetadata(key, (String) object);
+        else if(object instanceof Integer || object.getClass().equals(int.class))
+          destMessage.addMetadata(key, Integer.toString((int) object));
+        else if(object instanceof Boolean || object.getClass().equals(boolean.class))
+          destMessage.addMetadata(key, Boolean.toString((boolean) object));
+        else if(object instanceof Long || object.getClass().equals(long.class))
+          destMessage.addMetadata(key, Long.toString((long) object));
+        else if(object instanceof Double || object.getClass().equals(double.class))
+          destMessage.addMetadata(key, Double.toString((double) object));
+        else if(object instanceof Float || object.getClass().equals(float.class))
+          destMessage.addMetadata(key, Float.toString((float) object));
+        else if(object instanceof Short || object.getClass().equals(short.class))
+          destMessage.addMetadata(key, Short.toString((short) object));
+      }
+    }
+  }
+  
+  public void applyPerMessageProperties(XMLMessage destMessage, AdaptrisMessage sourceMessage) throws SDTException {
+    if(getAckImmediately() != null) 
+      destMessage.setAckImmediately(Boolean.parseBoolean(sourceMessage.resolve(getAckImmediately())));
+    
+    if(getApplicationMessageId() != null)
+      destMessage.setApplicationMessageId(sourceMessage.resolve(getApplicationMessageId()));
+    
+    if(getAsReplyMessage() != null)
+      destMessage.setAsReplyMessage(Boolean.parseBoolean(sourceMessage.resolve(getAsReplyMessage())));
+    
+    if(getCorrelationId() != null)
+      destMessage.setCorrelationId(sourceMessage.resolve(getCorrelationId()));
+    
+    if(getCorrelationKey() != null)
+      destMessage.setCorrelationKey(sourceMessage.resolve(getCorrelationKey()));
+    
+    if(getClassOfService() != null) {
+      String resolvedValue = sourceMessage.resolve(getClassOfService());
+      destMessage.setCos(resolvedValue.equals("1") ? User_Cos.USER_COS_1 : resolvedValue.equals("2") ? User_Cos.USER_COS_2 : User_Cos.USER_COS_3);
+    }
+    
+    if(getDeliveryMode() != null) {
+      String resolvedValue = sourceMessage.resolve(getDeliveryMode());
+      destMessage.setDeliveryMode(resolvedValue.equals("DIRECT") ? DeliveryMode.DIRECT : resolvedValue.equals("NON_PERSISTENT") ? DeliveryMode.NON_PERSISTENT : DeliveryMode.PERSISTENT);
+    }
+    
+    if(getDmqEligible() != null) 
+      destMessage.setDMQEligible(Boolean.parseBoolean(sourceMessage.resolve(getDmqEligible())));
+    
+    if(getElidingEligible() != null) 
+      destMessage.setElidingEligible(Boolean.parseBoolean(sourceMessage.resolve(getElidingEligible())));
+    
+    if(getExpiration() != null) 
+      destMessage.setExpiration(Long.parseLong(sourceMessage.resolve(getExpiration())));
+    
+    if(getHttpContentEncoding() != null)
+      destMessage.setHTTPContentEncoding(sourceMessage.resolve(getHttpContentEncoding()));
+    
+    if(getHttpContentType() != null)
+      destMessage.setHTTPContentType(sourceMessage.resolve(getHttpContentType()));
+    
+    if(getPriority() != null)
+      destMessage.setPriority(Integer.parseInt(sourceMessage.resolve(getPriority())));
+    
+    if(getReplyToQueue() != null)
+      destMessage.setReplyTo(JCSMPFactory.onlyInstance().createQueue(sourceMessage.resolve(getReplyToQueue())));
+    
+    if(getReplyToTopic() != null)
+      destMessage.setReplyTo(JCSMPFactory.onlyInstance().createTopic(sourceMessage.resolve(getReplyToTopic())));
+    
+    if(getReplyToSuffix() != null)
+      destMessage.setReplyToSuffix(sourceMessage.resolve(getReplyToSuffix()));
+    
+    if(getSenderId() != null)
+      destMessage.setSenderId(sourceMessage.resolve(getSenderId()));
+    
+    if(getSenderTimestamp() != null)
+      destMessage.setSenderTimestamp(Long.parseLong(sourceMessage.resolve(getSenderTimestamp())));
+    
+    if(getSequenceNumber() != null)
+      destMessage.setSequenceNumber(Long.parseLong(sourceMessage.resolve(getSequenceNumber())));
+    
+    if(getTimeToLive() != null)
+      destMessage.setTimeToLive(Long.parseLong(sourceMessage.resolve(getTimeToLive())));
+    
+    if(getUserProperties() != null) {
+      SDTMap map = JCSMPFactory.onlyInstance().createMap();
+      for(KeyValuePair kvp : getUserProperties().getKeyValuePairs()) {
+        map.putString(kvp.getKey(), sourceMessage.resolve(kvp.getValue()));
+      }
+      destMessage.setProperties(map);
+    }
+    
+  }
+  
+}

--- a/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpTextMessageTranslator.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpTextMessageTranslator.java
@@ -27,7 +27,7 @@ public class SolaceJcsmpTextMessageTranslator extends SolaceJcsmpBaseTranslatorI
 
   private transient TextMessage textMessage;
   
-  public SolaceJcsmpTextMessageTranslator() {
+  public SolaceJcsmpTextMessageTranslator() { 
     super();
     textMessage = this.jcsmpFactory().createMessage(TextMessage.class);
   }

--- a/src/test/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpConnectionTest.java
+++ b/src/test/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpConnectionTest.java
@@ -50,6 +50,29 @@ public class SolaceJcsmpConnectionTest extends MockBaseTest {
     connection.setAdditionalDebug(true);
     connection.setConnectionErrorHandler(mockConnectionErrorHandler);
 
+    connection.getAdvancedProperties().setAckEventMode("SUPPORTED_ACK_EVENT_MODE_PER_MSG");
+    connection.getAdvancedProperties().setApplicationDescription("Interlok");
+    connection.getAdvancedProperties().setCalculateMessageExpiration(false);
+    connection.getAdvancedProperties().setClientAckMode(true);
+    connection.getAdvancedProperties().setGdReconnectFailAction("GD_RECONNECT_FAIL_ACTION_AUTO_RETRY");
+    connection.getAdvancedProperties().setGenerateRcvTimestamps(false);
+    connection.getAdvancedProperties().setGenerateSenderId(false);
+    connection.getAdvancedProperties().setGenerateSendTimestamps(false);
+    connection.getAdvancedProperties().setGenerateSequenceNumbers(false);
+    connection.getAdvancedProperties().setIgnoreDuplicateSubscriptionError(false);
+    connection.getAdvancedProperties().setIgnoreSubscriptionNotFoundError(false);
+    connection.getAdvancedProperties().setKrbServiceName(null);
+    connection.getAdvancedProperties().setMessageCallbackOnReactor(false);
+    connection.getAdvancedProperties().setNoLocal(false);
+    connection.getAdvancedProperties().setPubAckTime(1000);
+    connection.getAdvancedProperties().setPubAckWindowSize(1);
+    connection.getAdvancedProperties().setPubUseIntermediateDirectBuf(true);
+    connection.getAdvancedProperties().setReapplySubscriptions(false);
+    connection.getAdvancedProperties().setReapplySubscriptions(false);
+    connection.getAdvancedProperties().setSubAckTime(1000);
+    connection.getAdvancedProperties().setSubAckWindowSize(1);
+    connection.getAdvancedProperties().setSubAckWindowThreshold(60);
+    
     connection.prepareConnection();
 
     when(mockJcsmpFactory.createSession(any(JCSMPProperties.class)))


### PR DESCRIPTION
## Motivation

Solace have performed an update of the API, deprecating the producers event handling in favour of a new API.  In this PR we have re-written the event handler to use the latest API while maintaining feature and config parity.

At the same time we have enabled the user to configure some of the more advanced properties on the connection object.  Essentially we have taken all of the available fields and simply made them visible for editing, such as; connection retries, acknowledgement window sizes and many more.

Finally, we have exposed many of the message properties when consuming and producing.  Essentially matching the idea of headers in a JMS message.  Solaces version doesn't really have a list of headers but instead a bunch of field getter/setters.

## Modification

Added a new AdvancedConnectionProperties object that will only show in the UI when editing in "advanced" mode.  This class simply exposes more options for the end user when connecting to a Solace broker.  All field defaults have been set according to Solaces own documentation.

A similar class has been created for the per-message-properties when consuming/producing individual messages.  When consuming you can configure the message translator to copy message field values directly into metadata keys and using the same object when producing you can configure expressions/static values to populate the fields.
The old way of doing this was a confusing reflection based idea, which has now been deprecated, marked for removal in v5.

The produce event handler has been updated to the latest API, which doesn't effect config at all.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

1) Users can now configure advanced connection properties.
2) Users can now configure which fields they wish to set/get on a per message basis.
3) Feature/config parity after an API upgrade.

## Testing

See the enclosed config.  It will need a Solace docker instance started locally.  Note javadoc has also been updated for help when configuring, so do build that jar and drop in the docs directory too.

[Solace.txt](https://github.com/adaptris/interlok-solace/files/7176935/Solace.txt)

