### PR TITLE
INTERLOK-3870 lgtm alert

### DIFF
--- a/src/main/java/com/adaptris/core/jcsmp/solace/auth/CertificateAuthenticationProvider.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/auth/CertificateAuthenticationProvider.java
@@ -36,53 +36,58 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
   @Getter
   @Setter
   private Boolean validateCertificate;
-  
+
   /**
    * The Solace session property to determine whether to validate the client certificate date.
-   * @param validateCertificate
+   *
+   * @param validateCertificateDate
    */
   @Getter
   @Setter
   private Boolean validateCertificateDate;
-  
+
   /**
    * The Solace client property to specify the location of your trust store.
-   * @param validateCertificate
+   *
+   * @param sslTrustStoreLocation
    */
   @Getter
   @Setter
   private String sslTrustStoreLocation;
-  
+
   /**
-   * The Solace client property to specify the password of your trust store.
-   * Note this password can also be encoded using the appropriate {@link com.adaptris.security.password.Password} 
-   * @param validateCertificate
+   * The Solace client property to specify the password of your trust store. Note this password can also be encoded using the appropriate
+   * {@link com.adaptris.security.password.Password}
+   *
+   * @param sslTrustStorePassword
    */
   @InputFieldHint(style = "PASSWORD", external=true)
   @Getter
   @Setter
   private String sslTrustStorePassword;
-  
+
   /**
    * (Optional) This property is used to specify the format of the truststore given in SSL_TRUST_STORE.
+   *
+   * @param sslTrustStoreFormat
    */
   @Getter
   @Setter
   private String sslTrustStoreFormat;
-  
+
   /**
-   * This property is used to specify a comma separated list of acceptable common 
-   * names for matching with server certificates. The API performs a case insensitive 
-   * comparison of the common names provided in this property with the common name in the 
-   * server certificate. Note that leading and trailing whitespaces are considered to be 
-   * part of the common names and are not ignored. An empty string means accept all common 
-   * names. No common name validation will be performed (overriding this property) 
+   * This property is used to specify a comma separated list of acceptable common
+   * names for matching with server certificates. The API performs a case insensitive
+   * comparison of the common names provided in this property with the common name in the
+   * server certificate. Note that leading and trailing whitespaces are considered to be
+   * part of the common names and are not ignored. An empty string means accept all common
+   * names. No common name validation will be performed (overriding this property)
    * if SSL_VALIDATE_CERTIFICATE is set to false.
    */
   @Getter
   @Setter
   private String sslTrustedCommonNameList;
-  
+
   /**
    * The Solace client property to specify the location of your key store.
    * @param validateCertificate
@@ -90,68 +95,68 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
   @Getter
   @Setter
   private String sslKeyStoreLocation;
-  
+
   /**
    * The Solace client property to specify the password of your key store.
-   * Note this password can also be encoded using the appropriate {@link com.adaptris.security.password.Password} 
+   * Note this password can also be encoded using the appropriate {@link com.adaptris.security.password.Password}
    * @param validateCertificate
    */
   @InputFieldHint(style = "PASSWORD", external=true)
   @Getter
   @Setter
   private String sslKeyStorePassword;
-  
+
   /**
    * (Optional) This property is used to specify the format of the keystore given in SSL_KEY_STORE.
    */
   @Getter
   @Setter
   private String sslKeyStoreFormat;
-  
+
   /**
-   * This property is used to specify the alias of the private key to use for client certificate authentication. 
+   * This property is used to specify the alias of the private key to use for client certificate authentication.
    * If there is only one private key entry in the keystore specified by SSL_KEY_STORE, then this property doesn't have to be set.
    */
   @Getter
   @Setter
   @InputFieldDefault(value="")
   private String sslPrivateKeyAlias;
-  
+
   @Override
   public JCSMPProperties initConnectionProperties() throws CoreException {
     JCSMPProperties properties = new JCSMPProperties();
     try {
       properties.setProperty(JCSMPProperties.AUTHENTICATION_SCHEME, JCSMPProperties.AUTHENTICATION_SCHEME_CLIENT_CERTIFICATE);
-      
-      setProperty(properties, JCSMPProperties.SSL_VALIDATE_CERTIFICATE, 
-          noOpFunction(), 
+
+      setProperty(properties, JCSMPProperties.SSL_VALIDATE_CERTIFICATE,
+          noOpFunction(),
           Optional.ofNullable(getValidateCertificate()));
-      setProperty(properties, JCSMPProperties.SSL_VALIDATE_CERTIFICATE_DATE, 
-          noOpFunction(), 
+      setProperty(properties, JCSMPProperties.SSL_VALIDATE_CERTIFICATE_DATE,
+          noOpFunction(),
           Optional.ofNullable(getValidateCertificateDate()));
-      setProperty(properties, JCSMPProperties.SSL_TRUST_STORE, 
-          noOpFunction(), 
+      setProperty(properties, JCSMPProperties.SSL_TRUST_STORE,
+          noOpFunction(),
           Optional.ofNullable(getSslTrustStoreLocation()));
-      setProperty(properties, JCSMPProperties.SSL_TRUST_STORE_PASSWORD, 
-          decodeFunction(), 
+      setProperty(properties, JCSMPProperties.SSL_TRUST_STORE_PASSWORD,
+          decodeFunction(),
           Optional.ofNullable(getSslTrustStorePassword()));
-      setProperty(properties, JCSMPProperties.SSL_TRUST_STORE_FORMAT, 
-          noOpFunction(), 
+      setProperty(properties, JCSMPProperties.SSL_TRUST_STORE_FORMAT,
+          noOpFunction(),
           Optional.ofNullable(getSslTrustStoreFormat()));
-      setProperty(properties, JCSMPProperties.SSL_TRUSTED_COMMON_NAME_LIST, 
-          noOpFunction(), 
+      setProperty(properties, JCSMPProperties.SSL_TRUSTED_COMMON_NAME_LIST,
+          noOpFunction(),
           Optional.ofNullable(getSslTrustedCommonNameList()));
-      setProperty(properties, JCSMPProperties.SSL_KEY_STORE, 
-          noOpFunction(), 
+      setProperty(properties, JCSMPProperties.SSL_KEY_STORE,
+          noOpFunction(),
           Optional.ofNullable(getSslKeyStoreLocation()));
-      setProperty(properties, JCSMPProperties.SSL_PRIVATE_KEY_ALIAS, 
-          noOpFunction(), 
+      setProperty(properties, JCSMPProperties.SSL_PRIVATE_KEY_ALIAS,
+          noOpFunction(),
           Optional.ofNullable(getSslPrivateKeyAlias()));
-      setProperty(properties, JCSMPProperties.SSL_KEY_STORE_PASSWORD, 
-          decodeFunction(), 
+      setProperty(properties, JCSMPProperties.SSL_KEY_STORE_PASSWORD,
+          decodeFunction(),
           Optional.ofNullable(getSslKeyStorePassword()));
-      setProperty(properties, JCSMPProperties.SSL_KEY_STORE_FORMAT, 
-          decodeFunction(), 
+      setProperty(properties, JCSMPProperties.SSL_KEY_STORE_FORMAT,
+          decodeFunction(),
           Optional.ofNullable(getSslKeyStoreFormat()));
 
     } catch (Exception pe) {
@@ -162,10 +167,10 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
 
   private void setProperty(JCSMPProperties properties, String propertyName, Function<Object, Object> function, Optional<Object> optionalValue) {
     optionalValue
-        .map(function)
-        .ifPresent( value -> properties.setProperty(propertyName, optionalValue.get()));
+    .map(function)
+    .ifPresent( value -> properties.setProperty(propertyName, optionalValue.get()));
   }
-  
+
   private Function<Object, Object> decodeFunction() {
     return encodedPassword -> {
       try {
@@ -175,7 +180,7 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
       }
     };
   }
-  
+
   private Function<Object, Object> noOpFunction() {
     return value -> value;
   }

--- a/src/main/java/com/adaptris/core/jcsmp/solace/auth/CertificateAuthenticationProvider.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/auth/CertificateAuthenticationProvider.java
@@ -83,6 +83,8 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
    * part of the common names and are not ignored. An empty string means accept all common
    * names. No common name validation will be performed (overriding this property)
    * if SSL_VALIDATE_CERTIFICATE is set to false.
+   *
+   * @param sslTrustedCommonNameList
    */
   @Getter
   @Setter
@@ -90,16 +92,18 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
 
   /**
    * The Solace client property to specify the location of your key store.
-   * @param validateCertificate
+   *
+   * @param sslKeyStoreLocation
    */
   @Getter
   @Setter
   private String sslKeyStoreLocation;
 
   /**
-   * The Solace client property to specify the password of your key store.
-   * Note this password can also be encoded using the appropriate {@link com.adaptris.security.password.Password}
-   * @param validateCertificate
+   * The Solace client property to specify the password of your key store. Note this password can also be encoded using the appropriate
+   * {@link com.adaptris.security.password.Password}
+   *
+   * @param sslKeyStorePassword
    */
   @InputFieldHint(style = "PASSWORD", external=true)
   @Getter
@@ -108,14 +112,18 @@ public class CertificateAuthenticationProvider implements AuthenticationProvider
 
   /**
    * (Optional) This property is used to specify the format of the keystore given in SSL_KEY_STORE.
+   *
+   * @param sslKeyStoreFormat
    */
   @Getter
   @Setter
   private String sslKeyStoreFormat;
 
   /**
-   * This property is used to specify the alias of the private key to use for client certificate authentication.
-   * If there is only one private key entry in the keystore specified by SSL_KEY_STORE, then this property doesn't have to be set.
+   * This property is used to specify the alias of the private key to use for client certificate authentication. If there is only one
+   * private key entry in the keystore specified by SSL_KEY_STORE, then this property doesn't have to be set.
+   *
+   * @param sslPrivateKeyAlias
    */
   @Getter
   @Setter

--- a/src/main/java/com/adaptris/core/jms/solace/ConsumerCreator.java
+++ b/src/main/java/com/adaptris/core/jms/solace/ConsumerCreator.java
@@ -1,14 +1,17 @@
 package com.adaptris.core.jms.solace;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.Topic;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.core.jms.JmsActorConfig;
 import com.adaptris.core.jms.JmsDestination;
 import com.adaptris.core.jms.JmsDestination.DestinationType;
@@ -25,7 +28,7 @@ public class ConsumerCreator {
    */
   public MessageConsumer createQueueReceiver(String queueName, String selector, JmsActorConfig c,
       int maxRetries, int waitBetweenRetries)
-      throws JMSException {
+          throws JMSException {
     Session s = c.currentSession();
     Queue q = s.createQueue(queueName);
     return createConsumerWithRetry(s, q, selector, false, maxRetries, waitBetweenRetries);
@@ -73,7 +76,7 @@ public class ConsumerCreator {
     JMSException lastException = null;
 
     int retries = 0;
-    while((returnedConsumer == null) && ((retries <= maxRetries) || (maxRetries <= 0) )) {
+    while(returnedConsumer == null && (retries <= maxRetries || maxRetries <= 0 )) {
       try {
         returnedConsumer = session.createConsumer(destination, selector, noLocal);
       } catch(JMSException ex) {
@@ -81,7 +84,7 @@ public class ConsumerCreator {
         retries ++;
         log.error("Failed to create consumer, will retry ({}) and after {} seconds.", retries, waitBetweenRetries, ex);
         try {
-          Thread.sleep(waitBetweenRetries * 1000);
+          Thread.sleep(waitBetweenRetries * 1000L);
         } catch (InterruptedException e) {
           log.warn("Interrupted while trying to create a message consumer.  Exiting.");
           break;
@@ -90,8 +93,9 @@ public class ConsumerCreator {
       }
     }
 
-    if(returnedConsumer == null)
+    if(returnedConsumer == null) {
       throw lastException;
+    }
 
     return returnedConsumer;
   }


### PR DESCRIPTION
## Motivation

To fix alerts reported by lgtm

## Modification

- Add argument reference in the log string so the argument will be printed
- Set one operand to long to avoid overflow if the result is bigger than a int.
- Fix javadoc

## PR Checklist

- [x] been self-reviewed.

## Result

Nothing should change for the end user.  Just better / safer code and javadocs

## Testing

The build and tests should be successful.
