### PR TITLE
INTERLOK-3978 Message user data is configurable

### DIFF
--- a/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpPerMessageProperties.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpPerMessageProperties.java
@@ -2,12 +2,9 @@ package com.adaptris.core.jcsmp.solace.translator;
 
 import com.adaptris.annotation.InputFieldHint;
 import com.adaptris.core.AdaptrisMessage;
-import com.adaptris.util.KeyValuePair;
-import com.adaptris.util.KeyValuePairList;
 import com.solacesystems.jcsmp.DeliveryMode;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.SDTException;
-import com.solacesystems.jcsmp.SDTMap;
 import com.solacesystems.jcsmp.User_Cos;
 import com.solacesystems.jcsmp.XMLMessage;
 
@@ -15,14 +12,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 public class SolaceJcsmpPerMessageProperties {
-
-  /**
-   * Set the user data through name/values pairs
-   */
-  @Getter
-  @Setter
-  @InputFieldHint(expression=true)
-  private KeyValuePairList userProperties;
   
   /**
    * Set the ACK Immediately message property.
@@ -256,27 +245,6 @@ public class SolaceJcsmpPerMessageProperties {
     
     if(getTimeToLive() != null)
       destMessage.addMetadata(getTimeToLive(), Long.toString(sourceMessage.getTimeToLive()));
-    
-    if(sourceMessage.getProperties() != null) {
-      for(String key : sourceMessage.getProperties().keySet()) {
-        Object object = sourceMessage.getProperties().get(key);
-        
-        if(object instanceof String)
-          destMessage.addMetadata(key, (String) object);
-        else if(object instanceof Integer || object.getClass().equals(int.class))
-          destMessage.addMetadata(key, Integer.toString((int) object));
-        else if(object instanceof Boolean || object.getClass().equals(boolean.class))
-          destMessage.addMetadata(key, Boolean.toString((boolean) object));
-        else if(object instanceof Long || object.getClass().equals(long.class))
-          destMessage.addMetadata(key, Long.toString((long) object));
-        else if(object instanceof Double || object.getClass().equals(double.class))
-          destMessage.addMetadata(key, Double.toString((double) object));
-        else if(object instanceof Float || object.getClass().equals(float.class))
-          destMessage.addMetadata(key, Float.toString((float) object));
-        else if(object instanceof Short || object.getClass().equals(short.class))
-          destMessage.addMetadata(key, Short.toString((short) object));
-      }
-    }
   }
   
   public void applyPerMessageProperties(XMLMessage destMessage, AdaptrisMessage sourceMessage) throws SDTException {
@@ -343,14 +311,6 @@ public class SolaceJcsmpPerMessageProperties {
     
     if(getTimeToLive() != null)
       destMessage.setTimeToLive(Long.parseLong(sourceMessage.resolve(getTimeToLive())));
-    
-    if(getUserProperties() != null) {
-      SDTMap map = JCSMPFactory.onlyInstance().createMap();
-      for(KeyValuePair kvp : getUserProperties().getKeyValuePairs()) {
-        map.putString(kvp.getKey(), sourceMessage.resolve(kvp.getValue()));
-      }
-      destMessage.setProperties(map);
-    }
     
   }
   

--- a/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTranslator.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTranslator.java
@@ -1,0 +1,46 @@
+package com.adaptris.core.jcsmp.solace.translator;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.MetadataCollection;
+import com.adaptris.core.MetadataElement;
+import com.adaptris.core.metadata.MetadataFilter;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.SDTException;
+import com.solacesystems.jcsmp.SDTMap;
+import com.solacesystems.jcsmp.XMLMessage;
+
+public class SolaceJcsmpUserDataTranslator {
+
+  public void translate(XMLMessage source, AdaptrisMessage destination) throws SDTException {
+    if(source.getProperties() != null) {
+      for(String key : source.getProperties().keySet()) {
+        Object object = source.getProperties().get(key);
+        
+        if(object instanceof String)
+          destination.addMetadata(key, (String) object);
+        else if(object instanceof Integer || object.getClass().equals(int.class))
+          destination.addMetadata(key, Integer.toString((int) object));
+        else if(object instanceof Boolean || object.getClass().equals(boolean.class))
+          destination.addMetadata(key, Boolean.toString((boolean) object));
+        else if(object instanceof Long || object.getClass().equals(long.class))
+          destination.addMetadata(key, Long.toString((long) object));
+        else if(object instanceof Double || object.getClass().equals(double.class))
+          destination.addMetadata(key, Double.toString((double) object));
+        else if(object instanceof Float || object.getClass().equals(float.class))
+          destination.addMetadata(key, Float.toString((float) object));
+        else if(object instanceof Short || object.getClass().equals(short.class))
+          destination.addMetadata(key, Short.toString((short) object));
+      }
+    }
+  }
+  
+  public void translate(AdaptrisMessage source, XMLMessage destination, MetadataFilter metadataFilter) throws SDTException {
+    MetadataCollection metadataCollection = metadataFilter.filter(source);
+    
+    SDTMap map = JCSMPFactory.onlyInstance().createMap();
+    for(MetadataElement element : metadataCollection) {
+      map.putString(element.getKey(), source.resolve(element.getValue()));
+    }
+    destination.setProperties(map);
+  }
+}

--- a/src/test/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpTextMessageTranslatorTest.java
+++ b/src/test/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpTextMessageTranslatorTest.java
@@ -11,8 +11,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.MockBaseTest;
 import com.adaptris.core.jcsmp.solace.SolaceJcsmpMetadataMapping;
-import com.adaptris.util.KeyValuePair;
-import com.adaptris.util.KeyValuePairList;
+import com.adaptris.core.metadata.RegexMetadataFilter;
 import com.solacesystems.jcsmp.DeliveryMode;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.TextMessage;
@@ -118,17 +117,12 @@ public class SolaceJcsmpTextMessageTranslatorTest extends MockBaseTest {
   @Test
   public void testTranslateAdaptrisTextMessageWithPerMessagePropertiesAndSDT() throws Exception {
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage(MESSAGE_CONTENT);
+    adaptrisMessage.addMetadata("key1", "value1");
+    adaptrisMessage.addMetadata("key2", "value2");
+    adaptrisMessage.addMetadata("key3", "value3");
     
-    SolaceJcsmpPerMessageProperties pmp = new SolaceJcsmpPerMessageProperties();
-    KeyValuePairList list = new KeyValuePairList();
-    list.add(new KeyValuePair("key1", "value1"));
-    list.add(new KeyValuePair("key2", "value2"));
-    list.add(new KeyValuePair("key3", "value3"));
-    
-    translator.setPerMessageProperties(pmp);
-    translator.setApplyPerMessagePropertiesOnProduce(true);
-    translator.setApplyPerMessagePropertiesOnConsume(true);
-    pmp.setUserProperties(list);
+    RegexMetadataFilter filter = new RegexMetadataFilter();
+    filter.addIncludePattern("key.*");
     
     TextMessage translatedMessage = (TextMessage) translator.translate(adaptrisMessage);
     AdaptrisMessage adaptrisMessage2 = translator.translate(translatedMessage);


### PR DESCRIPTION
## Motivation

We have been asked to give more control over consuming and producing message user data.
Previously you would have needed to specify the list of keys you want to consume and produce, which can be difficult if you're not aware of the keys for every message.

## Modification

When consuming a message we copy all Solace message user data into Adaptris message metadata.

When producing we have now enabled the user to specify a metadata filter, which will copy the keys and values into the Solace message user data map.

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI

## Result

User data is now fully configurable on the producing side and fully converted on consume.

