### PR TITLE
Added ability to specify specific user data type conversions

### DIFF
--- a/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpBaseTranslatorImp.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpBaseTranslatorImp.java
@@ -118,6 +118,11 @@ public abstract class SolaceJcsmpBaseTranslatorImp implements SolaceJcsmpMessage
   @AdvancedConfig(rare=true)
   private boolean applyPerMessagePropertiesOnConsume;
   
+  @Getter
+  @Setter
+  @AdvancedConfig(rare=true)
+  private List<SolaceJcsmpUserDataTypeMapping> typeMappings;
+  
   @Valid
   @AutoPopulated
   @AffectsMetadata
@@ -222,7 +227,7 @@ public abstract class SolaceJcsmpBaseTranslatorImp implements SolaceJcsmpMessage
     performHeaderMappings(message, solaceMessage);
     if(getApplyPerMessagePropertiesOnProduce())
       getPerMessageProperties().applyPerMessageProperties(solaceMessage, message);
-    getUserDataTranslator().translate(message, solaceMessage, metadataFilter());
+    getUserDataTranslator().translate(message, solaceMessage, metadataFilter(), getTypeMappings());
     
     return solaceMessage;
   }

--- a/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTranslator.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTranslator.java
@@ -1,5 +1,7 @@
 package com.adaptris.core.jcsmp.solace.translator;
 
+import java.util.List;
+
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.MetadataCollection;
 import com.adaptris.core.MetadataElement;
@@ -34,12 +36,20 @@ public class SolaceJcsmpUserDataTranslator {
     }
   }
   
-  public void translate(AdaptrisMessage source, XMLMessage destination, MetadataFilter metadataFilter) throws SDTException {
+  public void translate(AdaptrisMessage source, XMLMessage destination, MetadataFilter metadataFilter, List<SolaceJcsmpUserDataTypeMapping> dataTypeMappings) throws SDTException {
     MetadataCollection metadataCollection = metadataFilter.filter(source);
     
     SDTMap map = JCSMPFactory.onlyInstance().createMap();
     for(MetadataElement element : metadataCollection) {
       map.putString(element.getKey(), source.resolve(element.getValue()));
+      
+      if(dataTypeMappings != null) {
+        for(SolaceJcsmpUserDataTypeMapping mapping : dataTypeMappings) {
+          if(mapping.getMetadataKey().equals(element.getKey())) {
+            mapping.getDataType().addToMap(mapping.getMetadataKey(), source.resolve(element.getValue()), map);
+          }
+        }
+      }
     }
     destination.setProperties(map);
   }

--- a/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTypeEnum.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTypeEnum.java
@@ -1,0 +1,52 @@
+package com.adaptris.core.jcsmp.solace.translator;
+
+import com.solacesystems.jcsmp.SDTException;
+import com.solacesystems.jcsmp.SDTMap;
+
+public enum SolaceJcsmpUserDataTypeEnum {
+
+  Integer_Number {
+    @Override
+    public void addToMap(String key, String value, SDTMap map) throws SDTException {
+      map.putInteger(key, Integer.parseInt(value));
+    }
+  },
+  
+  Long_Number {
+    @Override
+    public void addToMap(String key, String value, SDTMap map) throws SDTException {
+      map.putLong(key, Long.parseLong(value));
+    }
+  },
+  
+  Float_Number {
+    @Override
+    public void addToMap(String key, String value, SDTMap map) throws SDTException {
+      map.putFloat(key, Float.parseFloat(value));
+    }
+  },
+  
+  Short_Number {
+    @Override
+    public void addToMap(String key, String value, SDTMap map) throws SDTException {
+      map.putShort(key, Short.parseShort(value));
+    }
+  },
+  
+  Double_Number {
+    @Override
+    public void addToMap(String key, String value, SDTMap map) throws SDTException {
+      map.putDouble(key, Double.parseDouble(value));
+    }
+  },
+  
+  True_False {
+    @Override
+    public void addToMap(String key, String value, SDTMap map) throws SDTException {
+      map.putBoolean(key, Boolean.parseBoolean(value));
+    }
+  };
+  
+  public abstract void addToMap(String key, String value, SDTMap map) throws SDTException;
+  
+}

--- a/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTypeMapping.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTypeMapping.java
@@ -1,0 +1,26 @@
+package com.adaptris.core.jcsmp.solace.translator;
+
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@XStreamAlias("solace-jcsmp-user-data-type-mapping")
+public class SolaceJcsmpUserDataTypeMapping {
+  
+  @Getter
+  @Setter
+  private String metadataKey;
+  
+  @Getter
+  @Setter
+  private SolaceJcsmpUserDataTypeEnum dataType;
+
+  public SolaceJcsmpUserDataTypeMapping() {
+  }
+  
+  public SolaceJcsmpUserDataTypeMapping(String metadataKey, SolaceJcsmpUserDataTypeEnum dataType) {
+    setMetadataKey(metadataKey);
+    setDataType(dataType);
+  }
+}

--- a/src/test/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTranslatorTest.java
+++ b/src/test/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpUserDataTranslatorTest.java
@@ -1,0 +1,106 @@
+package com.adaptris.core.jcsmp.solace.translator;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
+import com.adaptris.core.metadata.RegexMetadataFilter;
+import com.solacesystems.jcsmp.JCSMPFactory;
+import com.solacesystems.jcsmp.SDTMap;
+import com.solacesystems.jcsmp.XMLMessage;
+
+public class SolaceJcsmpUserDataTranslatorTest {
+
+  private SolaceJcsmpUserDataTranslator translator;
+  
+  private AdaptrisMessage adpMessage;
+  
+  private RegexMetadataFilter filter;
+  
+  private XMLMessage solMessage;
+  
+  private List<SolaceJcsmpUserDataTypeMapping> mappings;
+  
+  @Before
+  public void setUp() throws Exception {
+    translator = new SolaceJcsmpUserDataTranslator();
+    
+    adpMessage = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    adpMessage.addMessageHeader("integer", "1");
+    adpMessage.addMessageHeader("boolean", "true");
+    adpMessage.addMessageHeader("double", "1.11");
+    adpMessage.addMessageHeader("float", "1.1111");
+    
+    filter = new RegexMetadataFilter();
+    filter.addIncludePattern(".*");
+    
+    solMessage = JCSMPFactory.onlyInstance().createBytesXMLMessage();
+    
+    mappings = new ArrayList<>();
+    mappings.add(new SolaceJcsmpUserDataTypeMapping("integer", SolaceJcsmpUserDataTypeEnum.Integer_Number));
+    mappings.add(new SolaceJcsmpUserDataTypeMapping("boolean", SolaceJcsmpUserDataTypeEnum.True_False));
+    mappings.add(new SolaceJcsmpUserDataTypeMapping("double", SolaceJcsmpUserDataTypeEnum.Double_Number));
+    mappings.add(new SolaceJcsmpUserDataTypeMapping("float", SolaceJcsmpUserDataTypeEnum.Float_Number));
+  }
+  
+  @After
+  public void tearDown() throws Exception {
+    
+  }
+  
+  @Test
+  public void testUserDataTypeMappings() throws Exception {
+    translator.translate(adpMessage, solMessage, filter, mappings);
+    
+    assertEquals(Integer.class, solMessage.getProperties().get("integer").getClass());
+    assertEquals(Boolean.class, solMessage.getProperties().get("boolean").getClass());
+    assertEquals(Double.class, solMessage.getProperties().get("double").getClass());
+    assertEquals(Float.class, solMessage.getProperties().get("float").getClass());
+  }
+  
+  @Test
+  public void testUserDataTypeMappingsOnlyOneMapping() throws Exception {
+    mappings = new ArrayList<>();
+    mappings.add(new SolaceJcsmpUserDataTypeMapping("integer", SolaceJcsmpUserDataTypeEnum.Integer_Number));
+    
+    translator.translate(adpMessage, solMessage, filter, mappings);
+    
+    assertEquals(Integer.class, solMessage.getProperties().get("integer").getClass());
+    assertEquals(String.class, solMessage.getProperties().get("boolean").getClass());
+    assertEquals(String.class, solMessage.getProperties().get("double").getClass());
+    assertEquals(String.class, solMessage.getProperties().get("float").getClass());
+  }
+  
+  @Test
+  public void testUserDataToMetadata() throws Exception {
+    SDTMap map = JCSMPFactory.onlyInstance().createMap();
+    solMessage.setProperties(map);
+    
+    solMessage.getProperties().putString("string", "value");
+    solMessage.getProperties().putInteger("integer", 1);
+    solMessage.getProperties().putDouble("double", 1.11d);
+    solMessage.getProperties().putFloat("float", 1.1111f);
+    solMessage.getProperties().putLong("long", Long.parseLong("11111"));
+    solMessage.getProperties().putShort("short", Short.parseShort("1"));
+    solMessage.getProperties().putBoolean("boolean", true);
+    
+    translator.translate(solMessage, adpMessage);
+    
+    assertEquals("value", adpMessage.getMessageHeaders().get("string"));
+    assertEquals("1", adpMessage.getMessageHeaders().get("integer"));
+    assertEquals("11111", adpMessage.getMessageHeaders().get("long"));
+    assertEquals("1.11", adpMessage.getMessageHeaders().get("double"));
+    assertEquals("1.1111", adpMessage.getMessageHeaders().get("float"));
+    assertEquals("true", adpMessage.getMessageHeaders().get("boolean"));
+    assertEquals("1", adpMessage.getMessageHeaders().get("short"));
+    
+  }
+  
+}


### PR DESCRIPTION
## Motivation

Solace message properties allow for data types other than strings.  Of course Interlok stores all metadata values only as strings.  We need a way to let users configure type mapping from metadata to a datatype of their choice when creating the properties on the solace message.

## Modification

Added a mapping class that lets the user chose from an enum the data type they want to convert the metadata to.  We also let the user specify the key of the metadata item.


