### PR TITLE
Added locking around the list of un-ack'd messages to fix thread timi…

### DIFF
--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAbstractProducer.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAbstractProducer.java
@@ -98,14 +98,16 @@ public abstract class SolaceJcsmpAbstractProducer extends ProduceOnlyProducerImp
 
       translatedMessage.setCorrelationKey(msg.getUniqueId());
 
-      jcsmpMessageProducer.send(translatedMessage, dest);
       getAsynEventHandler().addUnAckedMessage(msg);
+      jcsmpMessageProducer.send(translatedMessage, dest);
+      
       // Standard workflow will attempt to execute this after the produce,
       // let's remove them so it's handled by our async event handler.
       msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK);
       msg.getObjectHeaders().remove(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK);
     } catch (Exception ex) {
       setMessageProducer(null);
+      // remove from the list
       throw ExceptionHelper.wrapProduceException(ex);
     }
   }

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpProduceEventHandler.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpProduceEventHandler.java
@@ -144,11 +144,17 @@ public class SolaceJcsmpProduceEventHandler implements JCSMPStreamingPublishCorr
 
   @SuppressWarnings("unchecked")
   public void addUnAckedMessage(AdaptrisMessage message) throws CoreException {
-    log.trace("Adding message to un'acked list with id {}", message.getUniqueId());
-    CallbackConsumers callbackConsumers = new CallbackConsumers(message,
-        (Consumer<AdaptrisMessage>) message.getObjectHeaders().get(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK),
-        (Consumer<AdaptrisMessage>) message.getObjectHeaders().get(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK));
-    this.getUnAckedMessages().put(message.getUniqueId(), callbackConsumers);
+    try {
+      getLock().lock();
+
+      log.trace("Adding message to un'acked list with id {}", message.getUniqueId());
+      CallbackConsumers callbackConsumers = new CallbackConsumers(message,
+          (Consumer<AdaptrisMessage>) message.getObjectHeaders().get(CoreConstants.OBJ_METADATA_ON_SUCCESS_CALLBACK),
+          (Consumer<AdaptrisMessage>) message.getObjectHeaders().get(CoreConstants.OBJ_METADATA_ON_FAILURE_CALLBACK));
+      this.getUnAckedMessages().put(message.getUniqueId(), callbackConsumers);
+    } finally {
+      getLock().unlock();
+    }
   }
 
   private void logRemainingUnAckedMessages() throws CoreException {


### PR DESCRIPTION
## Motivation

It is possible when producing that we add the current message to a list of un-acknowledged messages, but at the same time receive a success/fail notification for that message.  This can introduce timing issues, where we do not finish adding the message to the list before we check for it's existence in said list.

## Modification

Added a re-entrant lock around the handling of that list.

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

