### PR TITLE
Feature/interlok 4477

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ plugins {
 }
 
 ext {
-  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.0-SNAPSHOT'
-  releaseVersion = project.findProperty('releaseVersion') ?: '5.0-SNAPSHOT'
+  interlokCoreVersion = project.findProperty('interlokCoreVersion') ?: '5.1-SNAPSHOT'
+  releaseVersion = project.findProperty('releaseVersion') ?: '5.1-SNAPSHOT'
   nexusBaseUrl = project.findProperty('nexusBaseUrl') ?: 'https://nexus.adaptris.net/nexus'
   mavenPublishUrl = project.findProperty('mavenPublishUrl') ?: nexusBaseUrl + '/content/repositories/snapshots'
   javadocsBaseUrl = nexusBaseUrl + "/content/sites/javadocs/com/adaptris"
@@ -34,7 +34,7 @@ ext {
   organizationUrl = "http://interlok.adaptris.net"
   slf4jVersion = '2.0.17'
   mockitoVersion = '5.2.0'
-  solaceVersion='10.27.0'
+  solaceVersion='10.27.3'
 }
 
 ext.hostname = { ->
@@ -160,7 +160,7 @@ dependencies {
 
   api "com.solacesystems:sol-common:$solaceVersion"
   api "com.solacesystems:sol-jcsmp:$solaceVersion"
-  api "com.solacesystems:sol-jms:$solaceVersion"
+  api "com.solacesystems:sol-jms-jakarta:$solaceVersion"
 
   implementation ("org.slf4j:slf4j-api:$slf4jVersion")
   implementation ("net.jodah:expiringmap:0.5.11")

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAbstractConsumer.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAbstractConsumer.java
@@ -2,9 +2,9 @@ package com.adaptris.core.jcsmp.solace;
 
 import java.util.function.Consumer;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 import org.apache.commons.lang3.ObjectUtils;
 

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAbstractProducer.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAbstractProducer.java
@@ -2,7 +2,7 @@ package com.adaptris.core.jcsmp.solace;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAdvancedConnectionProperties.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpAdvancedConnectionProperties.java
@@ -30,7 +30,7 @@ import static com.solacesystems.jcsmp.JCSMPProperties.SUPPORTED_ACK_EVENT_MODE_W
 import static com.solacesystems.jcsmp.JCSMPProperties.SUPPORTED_MESSAGE_ACK_AUTO;
 import static com.solacesystems.jcsmp.JCSMPProperties.SUPPORTED_MESSAGE_ACK_CLIENT;
 
-import javax.validation.constraints.Pattern;
+import jakarta.validation.constraints.Pattern;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpConnection.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpConnection.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.jcsmp.solace;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import com.adaptris.annotation.AdapterComponent;

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpMetadataMapping.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpMetadataMapping.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.jcsmp.solace;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AutoPopulated;

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpQueueConsumer.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpQueueConsumer.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.jcsmp.solace;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpQueueProducer.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpQueueProducer.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.jcsmp.solace;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpTopicConsumer.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpTopicConsumer.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.jcsmp.solace;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpTopicProducer.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/SolaceJcsmpTopicProducer.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.jcsmp.solace;
 
-import javax.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;

--- a/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpBaseTranslatorImp.java
+++ b/src/main/java/com/adaptris/core/jcsmp/solace/translator/SolaceJcsmpBaseTranslatorImp.java
@@ -4,10 +4,10 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 import org.apache.commons.lang3.ObjectUtils;
 

--- a/src/main/java/com/adaptris/core/jms/solace/AdvancedSolaceImplementation.java
+++ b/src/main/java/com/adaptris/core/jms/solace/AdvancedSolaceImplementation.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.jms.JMSException;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import jakarta.jms.JMSException;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.AutoPopulated;

--- a/src/main/java/com/adaptris/core/jms/solace/BasicSolaceImplementation.java
+++ b/src/main/java/com/adaptris/core/jms/solace/BasicSolaceImplementation.java
@@ -1,8 +1,8 @@
 package com.adaptris.core.jms.solace;
 
-import javax.jms.JMSException;
-import javax.jms.MessageConsumer;
-import javax.validation.constraints.NotNull;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.validation.constraints.NotNull;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import com.adaptris.annotation.AdvancedConfig;

--- a/src/main/java/com/adaptris/core/jms/solace/ConsumerCreator.java
+++ b/src/main/java/com/adaptris/core/jms/solace/ConsumerCreator.java
@@ -2,12 +2,12 @@ package com.adaptris.core.jms.solace;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.MessageConsumer;
-import javax.jms.Queue;
-import javax.jms.Session;
-import javax.jms.Topic;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+import jakarta.jms.Topic;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/adaptris/core/jms/solace/DeliveryModeEnum.java
+++ b/src/main/java/com/adaptris/core/jms/solace/DeliveryModeEnum.java
@@ -1,6 +1,6 @@
 package com.adaptris.core.jms.solace;
 
-import javax.jms.DeliveryMode;
+import jakarta.jms.DeliveryMode;
 
 public enum DeliveryModeEnum {
   PERSISTENT(DeliveryMode.PERSISTENT),

--- a/src/main/java/com/adaptris/core/jms/solace/SolaceConsumerConnectionErrorHandler.java
+++ b/src/main/java/com/adaptris/core/jms/solace/SolaceConsumerConnectionErrorHandler.java
@@ -3,7 +3,7 @@ package com.adaptris.core.jms.solace;
 import java.lang.reflect.Field;
 import java.util.Set;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.ComponentProfile;

--- a/src/main/java/com/adaptris/core/jms/solace/SolaceJndiVendorImplementation.java
+++ b/src/main/java/com/adaptris/core/jms/solace/SolaceJndiVendorImplementation.java
@@ -1,7 +1,7 @@
 package com.adaptris.core.jms.solace;
 
-import javax.jms.JMSException;
-import javax.jms.MessageConsumer;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
 
 import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;

--- a/src/test/java/com/adaptris/core/jms/solace/AdvancedSolaceImplementationTest.java
+++ b/src/test/java/com/adaptris/core/jms/solace/AdvancedSolaceImplementationTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/adaptris/core/jms/solace/BasicSolaceImplementationTest.java
+++ b/src/test/java/com/adaptris/core/jms/solace/BasicSolaceImplementationTest.java
@@ -11,12 +11,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.MessageConsumer;
-import javax.jms.Queue;
-import javax.jms.Session;
-import javax.jms.Topic;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+import jakarta.jms.Topic;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/adaptris/core/jms/solace/ExtraParametersTest.java
+++ b/src/test/java/com/adaptris/core/jms/solace/ExtraParametersTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.jms.JMSException;
+import jakarta.jms.JMSException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/adaptris/core/jms/solace/SolaceConsumerConnectionErrorHandlerTest.java
+++ b/src/test/java/com/adaptris/core/jms/solace/SolaceConsumerConnectionErrorHandlerTest.java
@@ -9,9 +9,9 @@ import static org.mockito.Mockito.when;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.jms.Connection;
-import javax.jms.JMSException;
-import javax.jms.MessageConsumer;
+import jakarta.jms.Connection;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/adaptris/core/jms/solace/SolaceJndiVendorImplementationTest.java
+++ b/src/test/java/com/adaptris/core/jms/solace/SolaceJndiVendorImplementationTest.java
@@ -10,12 +10,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.MessageConsumer;
-import javax.jms.Queue;
-import javax.jms.Session;
-import javax.jms.Topic;
+import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.Queue;
+import jakarta.jms.Session;
+import jakarta.jms.Topic;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Motivation

INTERLOK-4477: Upgrade jakarta and jetty, make release version 5.1-SNAPSHOT

## Modification
Updated necessary dependencies and imports to use jakarta instead of javax


## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Compatibility with future versions of jakarta/jetty

## Testing


