### PR TITLE
Add Solace Connection State Handler

### DIFF
--- a/src/main/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandler.java
+++ b/src/main/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandler.java
@@ -18,60 +18,76 @@ import com.solacesystems.jms.events.SolConnectionEvent;
 import com.solacesystems.jms.events.SolConnectionEvent.EventType;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
-/**
- * A JMS connection state handler that listens for Solace connection-level events.
- */
+/** A JMS connection state handler that listens for Solace connection-level events. */
 @AdapterComponent
 @XStreamAlias("solace-connection-state-handler")
-@ComponentProfile(summary = "A JMS connection state handler that listens for Solace connection-level events and updates connection state.",
-        tag = "consumer,producer,jms,state-handler,solace")
-public class SolaceConnectionStateHandler extends ConnectionStateHandlerImp implements SolConnectionEventListener {
+@ComponentProfile(
+    summary =
+        "A JMS connection state handler that listens for Solace connection-level events and updates connection state.",
+    tag = "consumer,producer,jms,state-handler,solace")
+public class SolaceConnectionStateHandler extends ConnectionStateHandlerImp
+    implements SolConnectionEventListener {
 
-    private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
+  private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-    @Override
-    public void init() throws CoreException {
+  @Override
+  public void init() throws CoreException {}
+
+  @Override
+  public void start() throws CoreException {
+    try {
+      JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
+      Connection conn = jmsConn.currentConnection();
+
+      if (conn instanceof SolConnection solConn) {
+        solConn.setConnectionEventListener(this);
+        log.debug("Registered SolConnectionEventListener on Solace connection");
+      } else {
+        log.warn("Connection is not a SolConnection; connection-level events will not be detected");
+      }
+    } catch (Exception e) {
+      log.warn(
+          "Failed to register SolConnectionEventListener on connection; continuing without broker connection event handling",
+          e);
     }
+  }
 
-    @Override
-    public void start() throws CoreException {
-        try {
-            JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
-            Connection conn = jmsConn.currentConnection();
+  @Override
+  public void stop() {
+    deregisterListener();
+  }
 
-            if (conn instanceof SolConnection) {
-                SolConnection solConn = (SolConnection) conn;
-                solConn.setConnectionEventListener(this);
-                log.debug("Registered SolConnectionEventListener on Solace connection");
-            } else {
-                log.warn("Connection is not a SolConnection; connection-level events will not be detected");
-            }
-        } catch (Exception e) {
-            log.warn("Failed to register SolConnectionEventListener on connection; continuing without broker connection event handling", e);
-        }
+  @Override
+  public void close() {
+    deregisterListener();
+  }
+
+  private void deregisterListener() {
+    try {
+      JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
+      Connection conn = jmsConn.currentConnection();
+      if (conn instanceof SolConnection solConnection) {
+        solConnection.setConnectionEventListener(null);
+        log.debug("De-registered SolConnectionEventListener from Solace connection");
+      }
+    } catch (Exception e) {
+      log.trace("Failed to de-register SolConnectionEventListener (may already be closed)", e);
     }
+  }
 
-    @Override
-    public void stop() {
+  @Override
+  public void onEvent(SolConnectionEvent event) {
+    EventType eventType = event.getType();
+    JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
+
+    if (eventType == EventType.RECONNECTING) {
+      log.info("Solace RECONNECTING - updating connection state");
+      jmsConn.changeState(StoppedState.getInstance());
+    } else if (eventType == EventType.RECONNECTED) {
+      log.info("Solace RECONNECTED - updating connection state");
+      jmsConn.changeState(StartedState.getInstance());
+    } else {
+      log.warn("Received unknown Solace connection event type: {}", eventType);
     }
-
-    @Override
-    public void close() {
-    }
-
-    @Override
-    public void onEvent(SolConnectionEvent event) {
-        EventType eventType = event.getType();
-        JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
-
-        if (eventType == EventType.RECONNECTING) {
-            log.info("Solace RECONNECTING - updating connection state");
-            jmsConn.changeState(StoppedState.getInstance());
-        } else if (eventType == EventType.RECONNECTED) {
-            log.info("Solace RECONNECTED - updating connection state");
-            jmsConn.changeState(StartedState.getInstance());
-        } else {
-            log.warn("Received unknown Solace connection event type: {}", eventType);
-        }
-    }
+  }
 }

--- a/src/main/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandler.java
+++ b/src/main/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandler.java
@@ -24,54 +24,54 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @AdapterComponent
 @XStreamAlias("solace-connection-state-handler")
 @ComponentProfile(summary = "A JMS connection state handler that listens for Solace connection-level events and updates connection state.",
-    tag = "consumer,producer,jms,state-handler,solace")
+        tag = "consumer,producer,jms,state-handler,solace")
 public class SolaceConnectionStateHandler extends ConnectionStateHandlerImp implements SolConnectionEventListener {
 
-  private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
+    private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
-  @Override
-  public void init() throws CoreException {
-  }
-
-  @Override
-  public void start() throws CoreException {
-    try {
-      JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
-      Connection conn = jmsConn.currentConnection();
-
-      if (conn instanceof SolConnection) {
-        SolConnection solConn = (SolConnection) conn;
-        solConn.setConnectionEventListener(this);
-        log.debug("Registered SolConnectionEventListener on Solace connection");
-      } else {
-        log.warn("Connection is not a SolConnection; connection-level events will not be detected");
-      }
-    } catch (Exception e) {
-      log.warn("Failed to register SolConnectionEventListener on connection; continuing without broker connection event handling", e);
+    @Override
+    public void init() throws CoreException {
     }
-  }
 
-  @Override
-  public void stop() {
-  }
+    @Override
+    public void start() throws CoreException {
+        try {
+            JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
+            Connection conn = jmsConn.currentConnection();
 
-  @Override
-  public void close() {
-  }
-
-  @Override
-  public void onEvent(SolConnectionEvent event) {
-    EventType eventType = event.getType();
-    JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
-
-    if (eventType == EventType.RECONNECTING) {
-      log.info("Solace RECONNECTING - updating connection state");
-      jmsConn.changeState(StoppedState.getInstance());
-    } else if (eventType == EventType.RECONNECTED) {
-      log.info("Solace RECONNECTED - updating connection state");
-      jmsConn.changeState(StartedState.getInstance());
-    } else {
-      log.warn("Received unknown Solace connection event type: {}", eventType);
+            if (conn instanceof SolConnection) {
+                SolConnection solConn = (SolConnection) conn;
+                solConn.setConnectionEventListener(this);
+                log.debug("Registered SolConnectionEventListener on Solace connection");
+            } else {
+                log.warn("Connection is not a SolConnection; connection-level events will not be detected");
+            }
+        } catch (Exception e) {
+            log.warn("Failed to register SolConnectionEventListener on connection; continuing without broker connection event handling", e);
+        }
     }
-  }
+
+    @Override
+    public void stop() {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void onEvent(SolConnectionEvent event) {
+        EventType eventType = event.getType();
+        JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
+
+        if (eventType == EventType.RECONNECTING) {
+            log.info("Solace RECONNECTING - updating connection state");
+            jmsConn.changeState(StoppedState.getInstance());
+        } else if (eventType == EventType.RECONNECTED) {
+            log.info("Solace RECONNECTED - updating connection state");
+            jmsConn.changeState(StartedState.getInstance());
+        } else {
+            log.warn("Received unknown Solace connection event type: {}", eventType);
+        }
+    }
 }

--- a/src/main/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandler.java
+++ b/src/main/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandler.java
@@ -28,10 +28,14 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 public class SolaceConnectionStateHandler extends ConnectionStateHandlerImp
     implements SolConnectionEventListener {
 
-  private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
+  private final transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 
   @Override
-  public void init() throws CoreException {}
+  public void init() throws CoreException {
+    /* No need for initialization logic here since we will attempt to register the listener in
+    start(), and if it fails, we'll log a warning and continue without connection-level event
+    handling. */
+  }
 
   @Override
   public void start() throws CoreException {

--- a/src/main/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandler.java
+++ b/src/main/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandler.java
@@ -1,0 +1,77 @@
+package com.adaptris.core.jms.solace;
+
+import javax.jms.Connection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adaptris.annotation.AdapterComponent;
+import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.core.ConnectionStateHandlerImp;
+import com.adaptris.core.CoreException;
+import com.adaptris.core.StartedState;
+import com.adaptris.core.StoppedState;
+import com.adaptris.core.jms.JmsConnection;
+import com.solacesystems.jms.SolConnection;
+import com.solacesystems.jms.SolConnectionEventListener;
+import com.solacesystems.jms.events.SolConnectionEvent;
+import com.solacesystems.jms.events.SolConnectionEvent.EventType;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * A JMS connection state handler that listens for Solace connection-level events.
+ */
+@AdapterComponent
+@XStreamAlias("solace-connection-state-handler")
+@ComponentProfile(summary = "A JMS connection state handler that listens for Solace connection-level events and updates connection state.",
+    tag = "consumer,producer,jms,state-handler,solace")
+public class SolaceConnectionStateHandler extends ConnectionStateHandlerImp implements SolConnectionEventListener {
+
+  private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
+
+  @Override
+  public void init() throws CoreException {
+  }
+
+  @Override
+  public void start() throws CoreException {
+    try {
+      JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
+      Connection conn = jmsConn.currentConnection();
+
+      if (conn instanceof SolConnection) {
+        SolConnection solConn = (SolConnection) conn;
+        solConn.setConnectionEventListener(this);
+        log.debug("Registered SolConnectionEventListener on Solace connection");
+      } else {
+        log.warn("Connection is not a SolConnection; connection-level events will not be detected");
+      }
+    } catch (Exception e) {
+      log.warn("Failed to register SolConnectionEventListener on connection; continuing without broker connection event handling", e);
+    }
+  }
+
+  @Override
+  public void stop() {
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public void onEvent(SolConnectionEvent event) {
+    EventType eventType = event.getType();
+    JmsConnection jmsConn = retrieveConnection(JmsConnection.class);
+
+    if (eventType == EventType.RECONNECTING) {
+      log.info("Solace RECONNECTING - updating connection state");
+      jmsConn.changeState(StoppedState.getInstance());
+    } else if (eventType == EventType.RECONNECTED) {
+      log.info("Solace RECONNECTED - updating connection state");
+      jmsConn.changeState(StartedState.getInstance());
+    } else {
+      log.warn("Received unknown Solace connection event type: {}", eventType);
+    }
+  }
+}

--- a/src/test/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandlerTest.java
+++ b/src/test/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandlerTest.java
@@ -1,0 +1,107 @@
+package com.adaptris.core.jms.solace;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import javax.jms.Connection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.adaptris.core.MockBaseTest;
+import com.adaptris.core.StartedState;
+import com.adaptris.core.StoppedState;
+import com.adaptris.core.jms.JmsConnection;
+import com.solacesystems.jms.SolConnection;
+import com.solacesystems.jms.events.SolConnectionEvent;
+import com.solacesystems.jms.events.SolConnectionEvent.EventType;
+
+public class SolaceConnectionStateHandlerTest extends MockBaseTest {
+
+  private SolaceConnectionStateHandler stateHandler;
+
+  @Mock
+  private JmsConnection jmsConnection;
+  @Mock
+  private Connection genericJmsConnection;
+  @Mock
+  private SolConnection solConnection;
+  @Mock
+  private SolConnectionEvent event;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    stateHandler = new SolaceConnectionStateHandler();
+    stateHandler.registerConnection(jmsConnection);
+    when(jmsConnection.currentConnection()).thenReturn(genericJmsConnection);
+  }
+
+  @Test
+  public void testInitStopCloseNoOp() {
+    assertDoesNotThrow(() -> stateHandler.init());
+    assertDoesNotThrow(() -> stateHandler.stop());
+    assertDoesNotThrow(() -> stateHandler.close());
+  }
+
+  @Test
+  public void testStartRegistersListenerWhenConnectionIsSolaceConnection() {
+    when(jmsConnection.currentConnection()).thenReturn(solConnection);
+
+    assertDoesNotThrow(() -> stateHandler.start());
+
+    verify(solConnection).setConnectionEventListener(stateHandler);
+  }
+
+  @Test
+  public void testStartIgnoresNonSolaceConnection() {
+    assertDoesNotThrow(() -> stateHandler.start());
+
+    verifyNoInteractions(solConnection);
+  }
+
+  @Test
+  public void testStartSwallowsFailuresDuringListenerRegistration() {
+    when(jmsConnection.currentConnection()).thenThrow(new RuntimeException("boom"));
+
+    assertDoesNotThrow(() -> stateHandler.start());
+  }
+
+  @Test
+  public void testOnEventReconnectingSetsStoppedState() {
+    when(event.getType()).thenReturn(EventType.RECONNECTING);
+
+    stateHandler.onEvent(event);
+
+    verify(jmsConnection).changeState(StoppedState.getInstance());
+  }
+
+  @Test
+  public void testOnEventReconnectedSetsStartedState() {
+    when(event.getType()).thenReturn(EventType.RECONNECTED);
+
+    stateHandler.onEvent(event);
+
+    verify(jmsConnection).changeState(StartedState.getInstance());
+  }
+
+  @Test
+  public void testOnEventUnhandledTypeDoesNotChangeState() {
+    when(event.getType()).thenReturn(null);
+
+    stateHandler.onEvent(event);
+
+    verify(jmsConnection, never()).changeState(any());
+  }
+
+  @Test
+  public void testOnEventNullEventThrowsNullPointerException() {
+    assertThrows(NullPointerException.class, () -> stateHandler.onEvent(null));
+  }
+}
+

--- a/src/test/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandlerTest.java
+++ b/src/test/java/com/adaptris/core/jms/solace/SolaceConnectionStateHandlerTest.java
@@ -1,7 +1,6 @@
 package com.adaptris.core.jms.solace;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -22,35 +21,75 @@ import com.solacesystems.jms.SolConnection;
 import com.solacesystems.jms.events.SolConnectionEvent;
 import com.solacesystems.jms.events.SolConnectionEvent.EventType;
 
-public class SolaceConnectionStateHandlerTest extends MockBaseTest {
+class SolaceConnectionStateHandlerTest extends MockBaseTest {
 
   private SolaceConnectionStateHandler stateHandler;
 
-  @Mock
-  private JmsConnection jmsConnection;
-  @Mock
-  private Connection genericJmsConnection;
-  @Mock
-  private SolConnection solConnection;
-  @Mock
-  private SolConnectionEvent event;
+  @Mock private JmsConnection jmsConnection;
+  @Mock private Connection genericJmsConnection;
+  @Mock private SolConnection solConnection;
+  @Mock private SolConnectionEvent event;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  void setUp() {
     stateHandler = new SolaceConnectionStateHandler();
     stateHandler.registerConnection(jmsConnection);
     when(jmsConnection.currentConnection()).thenReturn(genericJmsConnection);
   }
 
   @Test
-  public void testInitStopCloseNoOp() {
+  void testInitNoOp() {
     assertDoesNotThrow(() -> stateHandler.init());
+  }
+
+  @Test
+  void testStopDeregistersListenerWhenConnectionIsSolaceConnection() {
+    when(jmsConnection.currentConnection()).thenReturn(solConnection);
+
+    stateHandler.stop();
+
+    verify(solConnection).setConnectionEventListener(null);
+  }
+
+  @Test
+  void testStopIgnoresNonSolaceConnection() {
+    stateHandler.stop();
+
+    verifyNoInteractions(solConnection);
+  }
+
+  @Test
+  void testStopSwallowsExceptions() {
+    when(jmsConnection.currentConnection()).thenThrow(new RuntimeException("boom"));
+
     assertDoesNotThrow(() -> stateHandler.stop());
+  }
+
+  @Test
+  void testCloseDeregistersListenerWhenConnectionIsSolaceConnection() {
+    when(jmsConnection.currentConnection()).thenReturn(solConnection);
+
+    stateHandler.close();
+
+    verify(solConnection).setConnectionEventListener(null);
+  }
+
+  @Test
+  void testCloseIgnoresNonSolaceConnection() {
+    stateHandler.close();
+
+    verifyNoInteractions(solConnection);
+  }
+
+  @Test
+  void testCloseSwallowsExceptions() {
+    when(jmsConnection.currentConnection()).thenThrow(new RuntimeException("boom"));
+
     assertDoesNotThrow(() -> stateHandler.close());
   }
 
   @Test
-  public void testStartRegistersListenerWhenConnectionIsSolaceConnection() {
+  void testStartRegistersListenerWhenConnectionIsSolaceConnection() {
     when(jmsConnection.currentConnection()).thenReturn(solConnection);
 
     assertDoesNotThrow(() -> stateHandler.start());
@@ -59,21 +98,21 @@ public class SolaceConnectionStateHandlerTest extends MockBaseTest {
   }
 
   @Test
-  public void testStartIgnoresNonSolaceConnection() {
+  void testStartIgnoresNonSolaceConnection() {
     assertDoesNotThrow(() -> stateHandler.start());
 
     verifyNoInteractions(solConnection);
   }
 
   @Test
-  public void testStartSwallowsFailuresDuringListenerRegistration() {
+  void testStartSwallowsFailuresDuringListenerRegistration() {
     when(jmsConnection.currentConnection()).thenThrow(new RuntimeException("boom"));
 
     assertDoesNotThrow(() -> stateHandler.start());
   }
 
   @Test
-  public void testOnEventReconnectingSetsStoppedState() {
+  void testOnEventReconnectingSetsStoppedState() {
     when(event.getType()).thenReturn(EventType.RECONNECTING);
 
     stateHandler.onEvent(event);
@@ -82,7 +121,7 @@ public class SolaceConnectionStateHandlerTest extends MockBaseTest {
   }
 
   @Test
-  public void testOnEventReconnectedSetsStartedState() {
+  void testOnEventReconnectedSetsStartedState() {
     when(event.getType()).thenReturn(EventType.RECONNECTED);
 
     stateHandler.onEvent(event);
@@ -91,17 +130,11 @@ public class SolaceConnectionStateHandlerTest extends MockBaseTest {
   }
 
   @Test
-  public void testOnEventUnhandledTypeDoesNotChangeState() {
+  void testOnEventUnhandledTypeDoesNotChangeState() {
     when(event.getType()).thenReturn(null);
 
     stateHandler.onEvent(event);
 
     verify(jmsConnection, never()).changeState(any());
   }
-
-  @Test
-  public void testOnEventNullEventThrowsNullPointerException() {
-    assertThrows(NullPointerException.class, () -> stateHandler.onEvent(null));
-  }
 }
-


### PR DESCRIPTION
## Motivation

To extend the connection state management for Solace connections. This change will listen for Solace connection RECONNECTING and RECONNECTED events and change the state of the connection accordingly.

## Modification

- Added a new Solace ConnectionStateHandler
- Depends on https://github.com/adaptris/interlok/pull/2061

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [x] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

Solace connections will change state to stopped when reconnecting and to started when reconnected

## Testing

- This should be tested as part of: https://github.com/adaptris/interlok-workflow-rest-services/pull/988
- You can use JConsole to monitor the state of the connections when you bring the Solace container up or down

